### PR TITLE
Minor updates

### DIFF
--- a/src/asoiaf/boltons/combatUnits.ts
+++ b/src/asoiaf/boltons/combatUnits.ts
@@ -1,19 +1,19 @@
 import { CardData, CardTypes } from '../types';
 
 const cardData: CardData = {
-  "Bastard's Girls (Bolton)": {
-    name: "Bastard's Girls (Bolton)",
+  "Bastard's Girls": {
+    name: "Bastard's Girls",
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-bastards-girls.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-bastards-girls-back.png',
   },
-  'Blackguards (Bolton)': {
-    name: 'Blackguards (Bolton)',
+  'Blackguards': {
+    name: 'Blackguards',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-blackguards.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-blackguards-back.png',
   },
-  'Cutthroats (Bolton)': {
+  'Cutthroats': {
     name: 'Cutthroats (Bolton)',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-cutthroats.png',
@@ -31,7 +31,7 @@ const cardData: CardData = {
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-dreadfort-spearmen.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-dreadfort-spearmen-back.png',
   },
-  'Flayed Men (Bolton)': {
+  'Flayed Men': {
     name: 'Flayed Men (Bolton)',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-flayed-men.png',

--- a/src/asoiaf/boltons/combatUnits.ts
+++ b/src/asoiaf/boltons/combatUnits.ts
@@ -1,20 +1,20 @@
 import { CardData, CardTypes } from '../types';
 
 const cardData: CardData = {
-  "Bastard's Girls": {
-    name: "Bastard's Girls",
+  "Bastard's Girls (Bolton)": {
+    name: "Bastard's Girls (Bolton)",
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-bastards-girls.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-bastards-girls-back.png',
   },
-  'Blackguards': {
-    name: 'Blackguards',
+  'Blackguards (Bolton)': {
+    name: 'Blackguards (Bolton)',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-blackguards.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-blackguards-back.png',
   },
-  'Cutthroats': {
-    name: 'Cutthroats',
+  'Cutthroats (Bolton)': {
+    name: 'Cutthroats (Bolton)',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-cutthroats.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-cutthroats-back.png',
@@ -31,8 +31,8 @@ const cardData: CardData = {
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-dreadfort-spearmen.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-dreadfort-spearmen-back.png',
   },
-  'Flayed Men': {
-    name: 'Flayed Men',
+  'Flayed Men (Bolton)': {
+    name: 'Flayed Men (Bolton)',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-flayed-men.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-flayed-men-back.png',

--- a/src/asoiaf/boltons/combatUnits.ts
+++ b/src/asoiaf/boltons/combatUnits.ts
@@ -14,7 +14,7 @@ const cardData: CardData = {
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-blackguards-back.png',
   },
   'Cutthroats': {
-    name: 'Cutthroats (Bolton)',
+    name: 'Cutthroats',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-cutthroats.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-cutthroats-back.png',
@@ -32,7 +32,7 @@ const cardData: CardData = {
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-dreadfort-spearmen-back.png',
   },
   'Flayed Men': {
-    name: 'Flayed Men (Bolton)',
+    name: 'Flayed Men',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-flayed-men.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-flayed-men-back.png',

--- a/src/asoiaf/boltons/nonCombatUnits.ts
+++ b/src/asoiaf/boltons/nonCombatUnits.ts
@@ -13,8 +13,8 @@ const cardData: CardData = {
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-ramsay-snow-rh.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-ramsay-snow-rh-back.png',
   },
-  'Roose Bolton - Calculating and Cruel': {
-    name: 'Roose Bolton - Calculating and Cruel',
+  'Roose Bolton - Calculating and Cruel (Bolton)': {
+    name: 'Roose Bolton - Calculating and Cruel (Bolton)',
     type: CardTypes.NonCombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-roose-bolton-cac.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/hbo-roose-bolton-cac-back.png',

--- a/src/asoiaf/neutral/attachments.ts
+++ b/src/asoiaf/neutral/attachments.ts
@@ -37,8 +37,8 @@ const cardData: CardData = {
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-daario-naharis-rm.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-daario-naharis-rm-back.png',
   },
-  'Daario Naharis - Stormcrow Captain (Neutral)': {
-    name: 'Daario Naharis - Stormcrow Captain (Neutral)',
+  'Daario Naharis - Stormcrow Captain': {
+    name: 'Daario Naharis - Stormcrow Captain',
     type: CardTypes.Attachment,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-daario-naharis-sc.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-daario-naharis-sc-back.png',
@@ -125,8 +125,8 @@ const cardData: CardData = {
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-sandor-clegane-fb.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-sandor-clegane-fb-back.png',
   },
-  'Stormcrow Lieutenant (Neutral)': {
-    name: 'Stormcrow Lieutenant (Neutral)',
+  'Stormcrow Lieutenant': {
+    name: 'Stormcrow Lieutenant',
     type: CardTypes.Attachment,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-lieutenant.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-lieutenant-back.png',

--- a/src/asoiaf/neutral/combatUnits.ts
+++ b/src/asoiaf/neutral/combatUnits.ts
@@ -38,19 +38,19 @@ const cardData: CardData = {
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-hedge-knights-back.png',
   },
   "House Bolton Bastard's Girls": {
-    name: "House Bolton Bastard's Girls",
+    name: "House Bolton Bastard's Girls (Neutral)",
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-bastards-girls.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-bastards-girls-back.png',
   },
   'House Bolton Blackguards': {
-    name: 'House Bolton Blackguards',
+    name: 'House Bolton Blackguards (Neutral)',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-blackguards.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-blackguards-back.png',
   },
   'House Bolton Cutthroats': {
-    name: 'House Bolton Cutthroats',
+    name: 'House Bolton Cutthroats (Neutral)',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-cutthroats.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-cutthroats-back.png',
@@ -61,20 +61,20 @@ const cardData: CardData = {
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-flayed-men.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-flayed-men-back.png',
   },
-  'Stormcrow Archers (Neutral)': {
-    name: 'Stormcrow Archers (Neutral)',
+  'Stormcrow Archers': {
+    name: 'Stormcrow Archers',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-archers.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-archers-back.png',
   },
-  'Stormcrow Dervishes (Neutral)': {
-    name: 'Stormcrow Dervishes (Neutral)',
+  'Stormcrow Dervishes': {
+    name: 'Stormcrow Dervishes',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-dervishes.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-dervishes-back.png',
   },
-  'Stormcrow Mercenaries (Neutral)': {
-    name: 'Stormcrow Mercenaries (Neutral)',
+  'Stormcrow Mercenaries': {
+    name: 'Stormcrow Mercenaries',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-mercenaries.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-stormcrow-mercenaries-back.png',

--- a/src/asoiaf/neutral/combatUnits.ts
+++ b/src/asoiaf/neutral/combatUnits.ts
@@ -38,19 +38,19 @@ const cardData: CardData = {
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-hedge-knights-back.png',
   },
   "House Bolton Bastard's Girls": {
-    name: "House Bolton Bastard's Girls (Neutral)",
+    name: "House Bolton Bastard's Girls",
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-bastards-girls.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-bastards-girls-back.png',
   },
   'House Bolton Blackguards': {
-    name: 'House Bolton Blackguards (Neutral)',
+    name: 'House Bolton Blackguards',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-blackguards.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-blackguards-back.png',
   },
   'House Bolton Cutthroats': {
-    name: 'House Bolton Cutthroats (Neutral)',
+    name: 'House Bolton Cutthroats',
     type: CardTypes.CombatUnit,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-cutthroats.png',
     imageUrlBack: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-house-bolton-cutthroats-back.png',

--- a/src/asoiaf/neutral/tacticsCards.ts
+++ b/src/asoiaf/neutral/tacticsCards.ts
@@ -43,20 +43,20 @@ const cardData: CardData = {
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-t7.png',
     imageUrlBack: '',
   },
-  'Sellsword Negotiations - Daario Naharis (Neutral)': {
-    name: 'Sellsword Negotiations - Daario Naharis (Neutral)',
+  'Sellsword Negotiations - Daario Naharis': {
+    name: 'Sellsword Negotiations - Daario Naharis',
     type: CardTypes.TacticsCard,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-daario-naharis-sc-t1.png',
     imageUrlBack: '',
   },
-  'Sellsword Bravado - Daario Naharis (Neutral)': {
-    name: 'Sellsword Bravado - Daario Naharis (Neutral)',
+  'Sellsword Bravado - Daario Naharis': {
+    name: 'Sellsword Bravado - Daario Naharis',
     type: CardTypes.TacticsCard,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-daario-naharis-sc-t2.png',
     imageUrlBack: '',
   },
-  'Reckless Strikes - Daario Naharis (Neutral)': {
-    name: 'Reckless Strikes - Daario Naharis (Neutral)',
+  'Reckless Strikes - Daario Naharis': {
+    name: 'Reckless Strikes - Daario Naharis',
     type: CardTypes.TacticsCard,
     imageUrl: 'https://asoiaf-tmg-discord-bot.s3.amazonaws.com/images/n-daario-naharis-sc-t3.png',
     imageUrlBack: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,7 @@ const getCachedImageUrl = (imageUrl: string) => {
 try {
   const COMMAND_PREFIX = process.env.NODE_ENV === 'production' ? '!asoiaf' : '!devtest';
   const SHORT_COMMAND_PREFIX = process.env.NODE_ENV === 'production' ? '!a' : '!d';
-  const FRONT_OF_CARD_FLAG = '-front';
-  const SHORT_FRONT_OF_CARD_FLAG = '-f';
+  const BOTH_CARD_SIDES_FLAG = '-both';
   const BACK_OF_CARD_FLAG = '-back';
   const SHORT_BACK_OF_CARD_FLAG = '-b';
   const ALL_COMMANDER_CARDS_FLAG = '-all';
@@ -77,9 +76,9 @@ Available card types:
 - \`t:objective\` _(shorthand: \`t:ob\`)_
 - \`t:terrain\` _(shorthand: \`t:tr\`)_
 
-You can also just ask for the front or back of a card:
+You can also ask for both sides of a card or just the back:
 
-\`!a [search parameter] -front\` or \`!a [search parameter] -f\`
+\`!a [search parameter] -both\`
 \`!a [search parameter] -back\` or \`!a [search parameter] -b\`
 
 You can also request every tactics card along with the commander.
@@ -89,7 +88,7 @@ You can also request every tactics card along with the commander.
 
 To report bugs, typos, missing cards, or missing artwork, please go here: <https://github.com/brianchuchua/asoiaf-tmg-discord-bot/issues>
 
-(Or just ping me, @Manath, on the Discord server)
+(Or just ping me, @Manath, or @willybunks on the Discord server)
     `);
       return;
     }
@@ -203,19 +202,19 @@ _(Tip: Try \`!a help\` to see a list of commands.)_
       }
     }
 
-    let frontOnly = false;
+    //Requests are frontOnly by default - zz_NRW 2024/01/02
+    let frontOnly = true;
     let backOnly = false;
     let allCommanderTacticsCards = false;
-    if (command.includes(FRONT_OF_CARD_FLAG)) {
-      frontOnly = true;
-      command = command.replace(FRONT_OF_CARD_FLAG, '').trim();
-    } else if (command.includes(SHORT_FRONT_OF_CARD_FLAG)) {
-      frontOnly = true;
-      command = command.replace(SHORT_FRONT_OF_CARD_FLAG, '').trim();
+    if (command.includes(BOTH_CARD_SIDES_FLAG)) {
+      frontOnly = false;
+      command = command.replace(BOTH_CARD_SIDES_FLAG, '').trim();
     } else if (command.includes(BACK_OF_CARD_FLAG)) {
+      frontOnly = false;
       backOnly = true;
       command = command.replace(BACK_OF_CARD_FLAG, '').trim();
     } else if (command.includes(SHORT_BACK_OF_CARD_FLAG)) {
+      frontOnly = false;
       backOnly = true;
       command = command.replace(SHORT_BACK_OF_CARD_FLAG, '').trim();
     }


### PR DESCRIPTION
- There was a duplicate issue with Roose Bolton NCU (same name in Bolton & Neutral)
- Address common request to make cards frontOnly by default
- Removed "(Neutral)" from Stormcrow units to call them by default on exact matches